### PR TITLE
[DM-35475] Update build system, enable fatal warnings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,36 +1,12 @@
 name: CI
 
-"on": [push, pull_request]
+'on': [push, pull_request, workflow_dispatch]
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0 # full history for metadata
-          submodules: true
-
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.7
-
-      - name: Python install
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install -r requirements.txt
-          python -m pip install "ltd-conveyor<2.0.0"
-
-      - name: Build
-        run: |
-          make html
-
-      - name: Upload
-        if: ${{ github.event_name == 'push' }}
-        env:
-          LTD_PASSWORD: ${{ secrets.LTD_PASSWORD }}
-          LTD_USERNAME: ${{ secrets.LTD_USERNAME }}
-        run: |
-          ltd upload --gh --dir _build/html --product sqr-048
+  call-workflow:
+    uses: lsst-sqre/rubin-sphinx-technote-workflows/.github/workflows/ci.yaml@v1
+    with:
+      handle: sqr-048
+    secrets:
+      ltd_username: ${{ secrets.LTD_USERNAME }}
+      ltd_password: ${{ secrets.LTD_PASSWORD }}

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    = -n
+SPHINXOPTS    = -W --keep-going -n
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = _build

--- a/conf.py
+++ b/conf.py
@@ -1,22 +1,9 @@
-#!/usr/bin/env python
-#
-# Sphinx configuration file
-# see metadata.yaml in this repo to update document-specific metadata
+"""Sphinx configuration.
 
-import os
-from documenteer.sphinxconfig.technoteconf import configure_technote
+To learn more about the Sphinx configuration for technotes, and how to
+customize it, see:
 
-# Ingest settings from metadata.yaml and use documenteer's configure_technote()
-# to build a Sphinx configuration that is injected into this script's global
-# namespace.
-metadata_path = os.path.join(os.path.dirname(__file__), 'metadata.yaml')
-with open(metadata_path, 'r') as f:
-    confs = configure_technote(f)
-g = globals()
-g.update(confs)
+https://documenteer.lsst.io/technotes/configuration.html
+"""
 
-# Add intersphinx inventories as needed
-# http://www.sphinx-doc.org/en/stable/ext/intersphinx.html
-# Example:
-#
-#     intersphinx_mapping['python'] = ('https://docs.python.org/3', None)
+from documenteer.conf.technote import *  # noqa: F401, F403

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-documenteer[technote]>=0.5.4,<0.6.0
+documenteer[technote]


### PR DESCRIPTION
- Use the latest documenteer, Sphinx configuration, and GitHub Actions workflow
- Add a dependabot configuration
- Tell Sphinx to exit with an error on any warning